### PR TITLE
Allow free extensions to overwrite installer files as well

### DIFF
--- a/src/projects/release.xml
+++ b/src/projects/release.xml
@@ -134,7 +134,7 @@
         </if>
 
         <!-- Copy the free source folder to a temporary location -->
-        <copy todir="${packages.tmp.path}">
+        <copy todir="${packages.tmp.path}" overwrite="true">
             <fileset dir="${project.free.source.path}" id="free-code">
                 <include name="**"/>
             </fileset>


### PR DESCRIPTION
AllediaInstaller includes it's own jQuery and was overwriting the one I use in Simplerenew. This is a potential source of conflict.
